### PR TITLE
Workarounds for nullpointer in ProxyServlet-initialization and issue with default alias

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.4</version>
+            <version>4.3.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/bundle/src/main/java/eu/fusepool/p3/webid/proxy/ProxyServlet.java
+++ b/bundle/src/main/java/eu/fusepool/p3/webid/proxy/ProxyServlet.java
@@ -60,7 +60,7 @@ import org.osgi.service.log.LogService;
  * @author Pascal Mainini
  */
 // refer to https://felix.apache.org/documentation/subprojects/apache-felix-http-service.html
-@Component(service = Servlet.class, property = {"alias=/", "TargetBaseURI=http://localhost:8088"})
+@Component(service = Servlet.class, property = {"alias=/proxy", "TargetBaseURI=http://localhost:8088"})
 @SuppressWarnings("serial")
 public class ProxyServlet extends HttpServlet {
 
@@ -257,7 +257,7 @@ public class ProxyServlet extends HttpServlet {
             log.log(LogService.LOG_INFO, "Configuring service...");
             if (properties.containsKey(PROPERTY_TARGET_BASE_URI)) {
                 targetBaseUri = (String) properties.get(PROPERTY_TARGET_BASE_URI);
-                log.log(LogService.LOG_INFO, "Proxy enabled, target: " + targetBaseUri);
+                log.log(LogService.LOG_INFO, "Proxy enabled, base: " + properties.get("alias") + ", target: " + targetBaseUri);
             } else {
                 targetBaseUri = null;
             }

--- a/bundle/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/bundle/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -22,6 +22,7 @@
          name="Fusepool P3 WebID Proxy"
          description="Configuration of the Fusepool P3 WebID Proxy">
         <AD id="TargetBaseURI" type="String" default="http://localhost:8088" name="Target Base URI" description="Specifies base URI of the resources to which the proxy proxies."/>
+        <AD id="alias" type="String" default="/proxy" name="Proxy Base URI" description="Specifies base URI of the proxy itself (on this host)"/>
     </OCD>
     <Designate pid="eu.fusepool.p3.webid.proxy.ProxyServlet">
         <Object ocdref="eu.fusepool.p3.webid.proxy.ProxyServlet"/>

--- a/bundlelist/pom.xml
+++ b/bundlelist/pom.xml
@@ -79,12 +79,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-osgi</artifactId>
-            <version>4.4</version>
+            <version>4.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
-            <version>4.4</version>
+            <version>4.3.6</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
Latest version of httpclient included in the last update of the dependency-version contains a bug preventing the servlet to load (https://issues.apache.org/jira/browse/HTTPCLIENT-1611). As a workaround, we revert to the previous versions of httpclient and it's dependencies.

Also, with felix-SNAPSHOT, it seems impossible to register the ProxyServlet at /, so now it gets registered as a workaround at /proxy. Will revisit this behaviour when it will be clear on which felix-version we depend...
